### PR TITLE
Fix how Triggear resolves branch name based on tag hook data - base_r…

### DIFF
--- a/app/github_handler.py
+++ b/app/github_handler.py
@@ -118,7 +118,13 @@ class GithubHandler:
         collection = self.__mongo_client.registered[EventTypes.tagged]
         tag = data['ref'][10:]
         repo = data['repository']['full_name']
-        branch = data['base_ref'][11:]
+        branch = ''
+        if data['base_ref'].startstwith('/refs/tags'):
+            branch = data['base_ref'][11:]
+        elif data['base_ref'] is None:
+            pass
+        else:
+            branch = data['base_ref']
         sha = data['after']
         registration_query = {
             "repository": repo,

--- a/app/github_handler.py
+++ b/app/github_handler.py
@@ -119,10 +119,10 @@ class GithubHandler:
         tag = data['ref'][10:]
         repo = data['repository']['full_name']
         branch = ''
-        if data['base_ref'].startstwith('/refs/tags'):
-            branch = data['base_ref'][11:]
-        elif data['base_ref'] is None:
+        if data['base_ref'] is None:
             pass
+        elif data['base_ref'].startstwith('/refs/tags'):
+            branch = data['base_ref'][11:]
         else:
             branch = data['base_ref']
         sha = data['after']

--- a/app/github_handler.py
+++ b/app/github_handler.py
@@ -119,18 +119,12 @@ class GithubHandler:
         tag = data['ref'][10:]
         repo = data['repository']['full_name']
         branch = ''
-        if data['base_ref'] is None:
-            pass
-        elif data['base_ref'].startstwith('/refs/tags'):
-            branch = data['base_ref'][11:]
-        else:
-            branch = data['base_ref']
         sha = data['after']
         registration_query = {
             "repository": repo,
         }
         logging.warning(f"Hook details: tagged for query {registration_query} "
-                        f"(branch: {branch}, sha: {sha}, tag: {tag})")
+                        f"(sha: {sha}, tag: {tag})")
         await self.trigger_registered_jobs(
             collection=collection,
             query=registration_query,


### PR DESCRIPTION
…ef may be a tag_name, may be /refs/tags/tag_name, may be None in which case we are not able to provide branch